### PR TITLE
force utf-8 encoding when calling poetry to allow tox to parse logs

### DIFF
--- a/src/tox_poetry.py
+++ b/src/tox_poetry.py
@@ -51,8 +51,12 @@ def tox_testenv_install_deps(venv, action):
         cmd += ['-E', extra]
 
     action.setactivity('installdeps', ' '.join(cmd))
+    # Force UTF-8 encoding, since tox log parser epxects this (~ tox\action.py", line 128, in popen).
+    env = venv._get_os_environ()  # pylint: disable=protected-access
+    env["PYTHONIOENCODING"] = "UTF-8"
     venv._pcall(  # pylint: disable=protected-access
         cmd,
         action=action,
         cwd=project_root,
+        env=env,
     )

--- a/tests/test_tox_poetry.py
+++ b/tests/test_tox_poetry.py
@@ -2,15 +2,11 @@
 import pytest
 from tox.venv import tox_testenv_create
 
+import tox_poetry
 from tox_poetry import tox_testenv_install_deps
 
 
-def test_foo():
-    assert True
-
-
-@pytest.mark.skip()
-def test_install_deps_indexserver(newmocksession):
+def test_install_deps_indexserver(newmocksession, monkeypatch):
     mocksession = newmocksession(
         [],
         """\
@@ -22,6 +18,7 @@ def test_install_deps_indexserver(newmocksession):
     )
     venv = mocksession.getvenv("py123")
     with mocksession.newaction(venv.name, "getenv") as action:
+        monkeypatch.setattr(tox_poetry, "_is_poetry_project", True)
         tox_testenv_create(action=action, venv=venv)
         pcalls = mocksession._pcalls
         assert len(pcalls) == 1
@@ -33,4 +30,5 @@ def test_install_deps_indexserver(newmocksession):
 
         assert len(pcalls) == 1
         args = " ".join(pcalls[0].args)
-        assert args.endswith('/poetry install')
+        assert "poetry" in args and "install" in args
+        assert pcalls[0].env["PYTHONIOENCODING"] == "UTF-8"


### PR DESCRIPTION
Solves to #7 