### PR TITLE
use poetry to manage the venv directly

### DIFF
--- a/src/tox_poetry.py
+++ b/src/tox_poetry.py
@@ -1,3 +1,8 @@
+import base64
+import hashlib
+import os.path
+import re
+import subprocess
 import sys
 
 import pluggy
@@ -8,6 +13,23 @@ from tox.exception import InvocationError
 _hookimpl = pluggy.HookimplMarker('tox')
 
 _is_poetry_project = False
+
+
+def get_env_name(name, cwd):
+    name = name.lower()
+    name = name.replace('.', '-')
+    sanitized_name = re.sub(r'[ $`!*@"\\\r\n\t]', "_", name)[:42]
+    normalized_cwd = os.path.normcase(os.path.realpath(cwd))
+    h_bytes = hashlib.sha256(normalized_cwd.encode('utf-8')).digest()
+    h_str = base64.urlsafe_b64encode(h_bytes).decode('utf-8')[:8]
+
+    return f"{sanitized_name}-{h_str}"
+
+@_hookimpl
+def tox_addoption(parser):
+    parser.add_testenv_attribute(
+        "skip_poetry", "bool", "Disable poetry install", False,
+    )
 
 
 @_hookimpl(hookwrapper=True)
@@ -23,29 +45,43 @@ def tox_configure(config):
     if build_backend not in ['poetry.masonry.api', 'poetry.core.masonry.api']:
         return
 
+    name = pyproject['tool']['poetry']['name']
+    venv_prefix = get_env_name(name, config.toxinidir)
+    for envconfig in config.envconfigs.values():
+        suffix = '.'.join(map(str, envconfig.python_info.version_info[:2]))
+        venv_name = f'{venv_prefix}-py{suffix}'
+        envconfig.envdir = config.toxworkdir / venv_name
+
     global _is_poetry_project  # pylint: disable=global-statement
     _is_poetry_project = True
 
     config.skipsdist = True
 
 
+@_hookimpl()
+def tox_testenv_create(venv, action):
+    interp = venv.getsupportedinterpreter()
+    env = venv._get_os_environ()  # pylint: disable=protected-access
+    env["PYTHONIOENCODING"] = "UTF-8"
+    env["POETRY_VIRTUALENVS_PATH"] = venv.envconfig.config.toxworkdir
+    venv._pcall(
+        [
+             interp, '-m', 'poetry', 'env', 'use', interp,
+        ],
+        action=action,
+        cwd=venv.envconfig.config.toxinidir,
+        env=env,
+    )
+
+
 @_hookimpl(hookwrapper=True)
 def tox_testenv_install_deps(venv, action):
     yield
 
-    if not _is_poetry_project:
+    if not _is_poetry_project or venv.envconfig.skip_poetry is True:
         return
 
-    project_root = venv.envconfig.config.toxinidir
-
-    cmd = []
-    try:
-        cmd.append(venv.getcommandpath('poetry', venv=False))
-    except InvocationError:
-        cmd.append(sys.executable)
-        cmd.append("-m")
-        cmd.append("poetry")
-
+    cmd = [venv.getsupportedinterpreter(), '-m', 'poetry']
     cmd.append("install")
     for extra in venv.envconfig.extras:
         cmd += ['-E', extra]
@@ -54,9 +90,10 @@ def tox_testenv_install_deps(venv, action):
     # Force UTF-8 encoding, since tox log parser epxects this (~ tox\action.py", line 128, in popen).
     env = venv._get_os_environ()  # pylint: disable=protected-access
     env["PYTHONIOENCODING"] = "UTF-8"
+    env["POETRY_VIRTUALENVS_PATH"] = venv.envconfig.config.toxworkdir
     venv._pcall(  # pylint: disable=protected-access
         cmd,
         action=action,
-        cwd=project_root,
+        cwd=venv.envconfig.config.toxinidir,
         env=env,
     )


### PR DESCRIPTION
Instead of using poetry inside of the venv, which is not how it is really designed to be used, use the poetry command installed with the python interpreter to create the test suite and install stuff in it.